### PR TITLE
fix: update docs link url

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -13,7 +13,7 @@ export default function Footer(): JSX.Element {
                         <Link fontWeight="bold" href="https://interep.link" isExternal>
                             About
                         </Link>
-                        <Link fontWeight="bold" href="https://interep.link/docs" isExternal>
+                        <Link fontWeight="bold" href="https://docs.interep.link" isExternal>
                             Docs
                         </Link>
                     </HStack>


### PR DESCRIPTION
Although it seems the main website is https://interep.link/ (https://github.com/interep-project/.github)  
There are also 
- https://kovan.interep.link
- https://goerli.interep.link

Which had a wrong documentation documentation link (should point towards https://docs.interep.link)